### PR TITLE
chore: build package as part of npm prepare step

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "license": "MIT",
   "scripts": {
     "prebuild": "npm run lint",
+    "prepare": "tsc",
     "build": "tsc",
     "lint": "eslint src/** --fix",
     "coverage": "npm test -- --coverage --no-cache",


### PR DESCRIPTION
## Describe your changes

- When specifying the `@odata/parser` package source as github, this allows the source to be built as part of the `npm install` steps.

## Issue ticket number and link (if applicable)

N/A

## Checklist before requesting a review

- [x] Project license confirmed
- [x] Unit-test added & passed at local development environment
- [x] All CI check passed
- [x] Design Document (if applicable)